### PR TITLE
Persist AI target selection and use it in manual send

### DIFF
--- a/app/src/main/java/com/example/aipostbox/AiTargetStore.kt
+++ b/app/src/main/java/com/example/aipostbox/AiTargetStore.kt
@@ -1,0 +1,28 @@
+package com.example.aipostbox
+
+import android.content.Context
+
+object AiTargetStore {
+    private const val PREFS_NAME = "ai_target_prefs"
+    private const val KEY_SELECTED_INDEX = "selected_index"
+
+    val targets: List<String> = listOf(
+        "選択してください",
+        "ChatGPT",
+        "Claude",
+        "Gemini",
+        "その他"
+    )
+
+    fun selectedIndex(context: Context): Int {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val index = prefs.getInt(KEY_SELECTED_INDEX, 0)
+        return index.coerceIn(0, targets.lastIndex)
+    }
+
+    fun saveSelectedIndex(context: Context, index: Int) {
+        val safeIndex = index.coerceIn(0, targets.lastIndex)
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit().putInt(KEY_SELECTED_INDEX, safeIndex).apply()
+    }
+}

--- a/app/src/main/java/com/example/aipostbox/SettingsActivity.kt
+++ b/app/src/main/java/com/example/aipostbox/SettingsActivity.kt
@@ -1,11 +1,37 @@
 package com.example.aipostbox
 
 import android.os.Bundle
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
 import androidx.appcompat.app.AppCompatActivity
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_settings)
+
+        val spinner = findViewById<Spinner>(R.id.aiTargetSpinner)
+        val aiTargets = AiTargetStore.targets
+        val spinnerAdapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_item,
+            aiTargets
+        )
+        spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        spinner.adapter = spinnerAdapter
+        spinner.setSelection(AiTargetStore.selectedIndex(this))
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(
+                parent: AdapterView<*>,
+                view: android.view.View?,
+                position: Int,
+                id: Long
+            ) {
+                AiTargetStore.saveSelectedIndex(this@SettingsActivity, position)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) = Unit
+        }
     }
 }

--- a/app/src/main/java/com/example/aipostbox/UnsentMemosActivity.kt
+++ b/app/src/main/java/com/example/aipostbox/UnsentMemosActivity.kt
@@ -5,6 +5,7 @@ import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.Spinner
 import android.widget.Toast
+import android.widget.AdapterView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -20,7 +21,7 @@ class UnsentMemosActivity : AppCompatActivity() {
         val sendAllButton = findViewById<Button>(R.id.sendAllButton)
         val recyclerView = findViewById<RecyclerView>(R.id.unsentList)
 
-        val aiTargets = listOf("選択してください", "ChatGPT", "Gemini", "Claude")
+        val aiTargets = AiTargetStore.targets
         val spinnerAdapter = ArrayAdapter(
             this,
             android.R.layout.simple_spinner_item,
@@ -28,6 +29,19 @@ class UnsentMemosActivity : AppCompatActivity() {
         )
         spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = spinnerAdapter
+        spinner.setSelection(AiTargetStore.selectedIndex(this))
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(
+                parent: AdapterView<*>,
+                view: android.view.View?,
+                position: Int,
+                id: Long
+            ) {
+                AiTargetStore.saveSelectedIndex(this@UnsentMemosActivity, position)
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) = Unit
+        }
 
         adapter = UnsentMemoAdapter(
             MemoRepository.all(),
@@ -41,6 +55,7 @@ class UnsentMemosActivity : AppCompatActivity() {
 
         sendAllButton.setOnClickListener {
             val selection = spinner.selectedItemPosition
+            AiTargetStore.saveSelectedIndex(this, selection)
             if (selection == 0) {
                 Toast.makeText(this, "AIを選択してください", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -3,16 +3,21 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/black"
-    android:gravity="center"
     android:orientation="vertical"
     android:padding="16dp">
 
     <TextView
-        android:id="@+id/settingsPlaceholder"
+        android:id="@+id/settingsTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="設定画面（準備中）"
+        android:text="送信先AI"
         android:textColor="@android:color/white"
         android:textSize="18sp" />
+
+    <Spinner
+        android:id="@+id/aiTargetSpinner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp" />
 
 </LinearLayout>


### PR DESCRIPTION
### Motivation
- Provide a simple, persistent way for users to choose the AI/target app used when sending queued memos to prepare for future automatic send features. 
- Keep the existing screens and manual-send behavior while enabling selection state reuse across the app.

### Description
- Add `AiTargetStore` to centralize available targets and persist the selected index in `SharedPreferences` via `selectedIndex` and `saveSelectedIndex`.
- Wire a `Spinner` into `SettingsActivity` and its layout (`activity_settings.xml`) to let users choose and persist the AI target using `AiTargetStore`.
- Load and save the same `Spinner` state inside `UnsentMemosActivity`, and apply the selected target when performing the manual `sendAll` action (preventing send when no target is selected).
- Keep all API/network logic unchanged (no external API calls are added) and reuse the in-app targets list `AiTargetStore.targets`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807ef8e0188331bf170e788164ee42)